### PR TITLE
syntax fixes

### DIFF
--- a/quackery.py
+++ b/quackery.py
@@ -264,12 +264,18 @@ def quackery(source_string):
         from_return()
         to_return(-1)
 
-    def meta_cjump():
-        expect_number()
-        howmany = from_stack()
+    def meta_if():
         expect_number()
         if from_stack() == 0:
-            to_return(from_return() + howmany)
+            to_return(from_return() + 1)
+
+    def meta_iff():
+        expect_number()
+        if from_stack() == 0:
+            to_return(from_return() + 2)
+
+    def meta_else():
+        to_return(from_return() + 1)
 
     def meta_literal():
         pc = from_return() + 1
@@ -510,7 +516,9 @@ def quackery(source_string):
            'over':        over,         # (   x x --> x x x )
            ']done[':      meta_done,    # (       -->       )
            ']again[':     meta_again,   # (       -->       )
-           ']cjump[':     meta_cjump,   # (   b n -->       )
+           ']if[':        meta_if,      # (     b -->       )
+           ']iff[':       meta_iff,     # (     b -->       )
+           ']else[':      meta_else,    # (     b -->       )
            "]'[":         meta_literal, # (       --> x     )
            ']this[':      meta_this,    # (       --> [     )
            ']do[':        meta_do,      # (     x -->       )
@@ -794,11 +802,11 @@ def quackery(source_string):
 
   [ ]done[ ]                    is done         (         -->         )
 
-  [ 1 ]cjump[ ]                 is if           (     b n -->         )
+  [ ]if[ ]                      is if           (     b n -->         )
 
-  [ 2 ]cjump[ ]                 is iff          (     b n -->         )
+  [ ]iff[ ]                     is iff          (     b n -->         )
 
-  [ false 1 ]cjump[ ]           is else         (         -->         )
+  [ ]else[ ]                    is else         (         -->         )
 
   [ 2dup > if swap drop ]       is min          (   n n n --> n       )
 
@@ -1605,7 +1613,7 @@ def quackery(source_string):
      within unrot tuck bit mod nip / - < xor != or and not true false
      sharefile releasefile putfile filepath input ding emit quid
      operator? number? nest? size poke peek find join split [] take
-     immovable put ]bailby[ ]do[ ]this[ ]'[ ]cjump[ ]again[
+     immovable put ]bailby[ ]do[ ]this[ ]'[ ]if[ ]iff[ ]else[ ]again[
      ]done[ over rot swap drop dup return nestdepth stacksize time ~ ^
      | & >> << ** /mod * negate + 1+ > = nand fail python"
 
@@ -1631,7 +1639,7 @@ def quackery(source_string):
     within unrot tuck bit mod nip / - < xor != or and not true false
     sharefile releasefile putfile filepath input ding emit quid
     operator? number? nest? size poke peek find join split [] take
-    immovable put ]bailby[ ]do[ ]this[ ]'[ ]cjump[ ]again[
+    immovable put ]bailby[ ]do[ ]this[ ]'[ ]if[ ]iff[ ]else[ ]again[
     ]done[ over rot swap drop dup return nestdepth stacksize time ~ ^
     | & >> << ** /mod * negate + 1+ > = nand fail python ]
 

--- a/quackery.py
+++ b/quackery.py
@@ -680,7 +680,7 @@ def quackery(source_string):
         while char != delimiter:
             char = next_char()
             if char == '':
-                raise EOFError('No end of string found.')
+                raise EOFError('Endless string discovered.')
             if char != delimiter:
                 result.append(ord(char))
         current_build.append([[meta_literal], result])
@@ -1353,7 +1353,7 @@ def quackery(source_string):
         bail ]
     behead over find
     2dup swap found not if
-      [ $ 'Unterminated string discovered.'
+      [ $ 'Endless string discovered.'
         message put
         bail ]
     split behead drop

--- a/quackery.py
+++ b/quackery.py
@@ -512,7 +512,7 @@ def quackery(source_string):
            ']again[':     meta_again,   # (       -->       )
            ']if[':        meta_if,      # (     b -->       )
            ']iff[':       meta_iff,     # (     b -->       )
-           ']else[':      meta_else,    # (     b -->       )
+           ']else[':      meta_else,    # (       -->       )
            "]'[":         meta_literal, # (       --> x     )
            ']this[':      meta_this,    # (       --> [     )
            ']do[':        meta_do,      # (     x -->       )

--- a/quackery.py
+++ b/quackery.py
@@ -796,9 +796,9 @@ def quackery(source_string):
 
   [ ]done[ ]                    is done         (         -->         )
 
-  [ ]if[ ]                      is if           (     b n -->         )
+  [ ]if[ ]                      is if           (       b -->         )
 
-  [ ]iff[ ]                     is iff          (     b n -->         )
+  [ ]iff[ ]                     is iff          (       b -->         )
 
   [ ]else[ ]                    is else         (         -->         )
 
@@ -1607,7 +1607,7 @@ def quackery(source_string):
      within unrot tuck bit mod nip / - < xor != or and not true false
      sharefile releasefile putfile filepath input ding emit quid
      operator? number? nest? size poke peek find join split [] take
-     immovable put ]bailby[ ]do[ ]this[ ]'[ ]if[ ]iff[ ]else[ ]again[
+     immovable put ]bailby[ ]do[ ]this[ ]'[ ]else[ ]iff[ ]if[ ]again[
      ]done[ over rot swap drop dup return nestdepth stacksize time ~ ^
      | & >> << ** /mod * negate + 1+ > = nand fail python"
 
@@ -1633,7 +1633,7 @@ def quackery(source_string):
     within unrot tuck bit mod nip / - < xor != or and not true false
     sharefile releasefile putfile filepath input ding emit quid
     operator? number? nest? size poke peek find join split [] take
-    immovable put ]bailby[ ]do[ ]this[ ]'[ ]if[ ]iff[ ]else[ ]again[
+    immovable put ]bailby[ ]do[ ]this[ ]'[ ]else[ ]iff[ ]if[ ]again[
     ]done[ over rot swap drop dup return nestdepth stacksize time ~ ^
     | & >> << ** /mod * negate + 1+ > = nand fail python ]
 


### PR DESCRIPTION
`]cjump[` expects a number (how many to jump) and the boolean under that. ([SED here.](https://github.com/dragoncoder047/QuackeryFork/blob/8ebd49fc92bfa5fa0b26834c609d5ebf5bbbf5cd/quackery.py#L513
)) That allows a user to define their own `ifff`, `iffff`, etc. without having to edit the Quackery source file or resort to `dup ]iff[ ]iff[` hacks, and also to jump backwards with negative jump amounts such as `[ false -1 ]cjump[ ] is hang`. (Although I haven't encountered anywhere where that would be useful.)

I have not been able to edit the PDF documentation files, you will have to get that yourself. I haven't also checked the Rosetta Code pages to see where this would impact code there that uses`]if[`, `]iff[` and `]else[`, but nonetheless it would be a trivial drop-in substitution - each would simply be replaced by `1 ]cjump[`, `2 ]cjump[`, and `false 1 ]cjump[` respectively - and that's [pretty much what I did](https://github.com/dragoncoder047/QuackeryFork/blob/8ebd49fc92bfa5fa0b26834c609d5ebf5bbbf5cd/quackery.py#L797-L801) anyway in the definitions of `if`, `iff`, and `else`.

There are also a couple of minor syntax fixes to make the code more Pythonic (`return x` instead of `return(x)`, etc.)